### PR TITLE
add bugtracker link now that this is not hosted on robot_model anymore

### DIFF
--- a/joint_state_publisher/package.xml
+++ b/joint_state_publisher/package.xml
@@ -11,6 +11,8 @@
 
   <license>BSD</license>
   <url type="website">http://www.ros.org/wiki/joint_state_publisher</url>
+  <url type="repository">https://github.com/ros/joint_state_publisher</url>
+  <url type="bugtracker">https://github.com/ros/joint_state_publisher/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
Cherry-pick of 5e4777b64cc1ace0950478d2e937075ea30ac507