### PR TITLE
Only update one joint slider on value changed.

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -197,7 +197,9 @@ class JointStatePublisher():
                 joint['effort'] = effort
 
         if self.gui is not None:
-            # signal instead of directly calling the update_sliders method, to switch to the QThread
+            # Signal instead of directly calling the update_sliders method, to
+            # switch to the QThread.  Note that we do this only once at the end
+            # to avoid lots of overhead switching threads.
             self.gui.sliderUpdateTrigger.emit()
 
     def loop(self):
@@ -348,7 +350,8 @@ class JointStatePublisherGui(QWidget):
             self.joint_map[name] = {'slidervalue': 0, 'display': display,
                                     'slider': slider, 'joint': joint}
             # Connect to the signal provided by QSignal
-            slider.valueChanged.connect(self.onValueChanged)
+            slider.valueChanged.connect(lambda event,name=name: self.onValueChangedOne(name))
+
             sliders.append(joint_layout)
 
         # Determine number of rows to be used in grid
@@ -391,14 +394,14 @@ class JointStatePublisherGui(QWidget):
         self.vlayout.addWidget(self.maxrowsupdown)
         self.setLayout(self.vlayout)
 
-    @pyqtSlot(int)
-    def onValueChanged(self, event):
+    def onValueChangedOne(self, name):
+        print("On value changed %s" % (name))
         # A slider value was changed, but we need to change the joint_info metadata.
-        for name, joint_info in self.joint_map.items():
-            joint_info['slidervalue'] = joint_info['slider'].value()
-            joint = joint_info['joint']
-            joint['position'] = self.sliderToValue(joint_info['slidervalue'], joint)
-            joint_info['display'].setText("%.2f" % joint['position'])
+        joint_info = self.joint_map[name]
+        joint_info['slidervalue'] = joint_info['slider'].value()
+        joint = joint_info['joint']
+        joint['position'] = self.sliderToValue(joint_info['slidervalue'], joint)
+        joint_info['display'].setText("%.2f" % joint['position'])
 
     @pyqtSlot()
     def updateSliders(self):

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -395,7 +395,6 @@ class JointStatePublisherGui(QWidget):
         self.setLayout(self.vlayout)
 
     def onValueChangedOne(self, name):
-        print("On value changed %s" % (name))
         # A slider value was changed, but we need to change the joint_info metadata.
         joint_info = self.joint_map[name]
         joint_info['slidervalue'] = joint_info['slider'].value()


### PR DESCRIPTION
This should fix the issue raised in
https://github.com/ros/joint_state_publisher/pull/5.  The
basic problem is that update_sliders() changes the values
of the sliders, which causes the "onValueChanged" signal
to be emitted for each slider.  The problem is that both
update_sliders() and onValueChanged() iterate over the
entire list of joints, so onValueChanged() is re-evaluating
all sliders during each setValue() in the update_sliders()
loop.  To avoid this problem, change onValueChanged() to
only operate on the field that actually changed, which is
accomplished with a lambda.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>