### PR TITLE
ignore 'planar' joints just as 'fixed' and 'floating'

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -73,7 +73,7 @@ class JointStatePublisher():
                 continue
             if child.localName == 'joint':
                 jtype = child.getAttribute('type')
-                if jtype == 'fixed' or jtype == 'floating':
+                if jtype in ['fixed', 'floating', 'planar']:
                     continue
                 name = child.getAttribute('name')
                 self.joint_list.append(name)


### PR DESCRIPTION
Otherwise the publisher throws exceptions when the URDF contains a planar joint.