### PR TITLE
Pass node name as title and properly set it on GUI.

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -157,7 +157,7 @@ class JointStatePublisher():
         if use_gui:
             num_rows = get_param("num_rows", 0)
             self.app = QApplication(sys.argv)
-            self.gui = JointStatePublisherGui("Joint State Publisher", self, num_rows)
+            self.gui = JointStatePublisherGui(rospy.get_name()[1:], self, num_rows)
             self.gui.show()
         else:
             self.gui = None
@@ -303,6 +303,7 @@ class JointStatePublisherGui(QWidget):
 
     def __init__(self, title, jsp, num_rows=0):
         super(JointStatePublisherGui, self).__init__()
+        self.setWindowTitle(title)
         self.jsp = jsp
         self.joint_map = {}
         self.vlayout = QVBoxLayout(self)


### PR DESCRIPTION
Just a minor addition. I have explicitly set the title of GUI with the previously unused parameter. Also instead of sending `"Joint State Publisher"`, sending the node name should be a better idea when there are multiple instances of `joint_state_publisher` nodes publishing/subscribing to/from different topics and want to use GUI simultaneously.