### PR TITLE
encode to utf8

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -132,7 +132,7 @@ class JointStatePublisher():
                 self.free_joints[name] = joint
 
     def __init__(self):
-        description = get_param('robot_description')
+        description = get_param('robot_description').encode('utf-8')
 
         self.free_joints = {}
         self.joint_list = [] # for maintaining the original order of the joints


### PR DESCRIPTION
Fixes by just making sure the description is in utf8 : 
```
  File "/opt/ros/melodic/lib/joint_state_publisher/joint_state_publisher", line 474, in <module>
    jsp = JointStatePublisher()
  File "/opt/ros/melodic/lib/joint_state_publisher/joint_state_publisher", line 149, in __init__
    robot = xml.dom.minidom.parseString(description)
  File "/usr/lib/python2.7/xml/dom/minidom.py", line 1928, in parseString
    return expatbuilder.parseString(string)
  File "/usr/lib/python2.7/xml/dom/expatbuilder.py", line 940, in parseString
    return builder.parseString(string)
  File "/usr/lib/python2.7/xml/dom/expatbuilder.py", line 223, in parseString
    parser.Parse(string, True)
UnicodeEncodeError: 'ascii' codec can't encode character
```