### PR TITLE
Make it clear robot_description is required.

### DIFF
--- a/joint_state_publisher/README.md
+++ b/joint_state_publisher/README.md
@@ -21,6 +21,7 @@ Subscribed Topics
 
 Parameters
 ----------
+* `robot_description` (string, required) - A URDF or DAE file describing the robot.
 * `rate` (int) - The rate at which to publish updates to the `/joint_states` topic.  Defaults to 10.
 * `publish_default_positions` (bool) - Whether to publish a default position for each movable joint to the `/joint_states` topic.  If False, `use_gui` must also be False.  Defaults to True.
 * `publish_default_velocities` (bool) - Whether to publish a default velocity for each movable joint to the `/joint_states` topic.  Defaults to False.

--- a/joint_state_publisher/src/joint_state_publisher/__init__.py
+++ b/joint_state_publisher/src/joint_state_publisher/__init__.py
@@ -141,6 +141,8 @@ class JointStatePublisher():
 
     def __init__(self):
         description = get_param('robot_description')
+        if description is None:
+            raise RuntimeError('The robot_description parameter is required and not set.')
 
         self.free_joints = {}
         self.joint_list = [] # for maintaining the original order of the joints


### PR DESCRIPTION
Without this PR

```console
$ rosrun joint_state_publisher_gui  joint_state_publisher_gui
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-sloretz'
Traceback (most recent call last):
  File "/home/sloretz/ws/noetic-misc/devel_isolated/joint_state_publisher_gui/lib/joint_state_publisher_gui/joint_state_publisher_gui", line 15, in <module>
    exec(compile(fh.read(), python_script, 'exec'), context)
  File "/home/sloretz/ws/noetic-misc/src/joint_state_publisher/joint_state_publisher_gui/scripts/joint_state_publisher_gui", line 52, in <module>
    joint_state_publisher.JointStatePublisher(),
  File "<string>", line 157, in __init__
  File "/usr/lib/python3.8/xml/dom/minidom.py", line 1969, in parseString
    return expatbuilder.parseString(string)
  File "/usr/lib/python3.8/xml/dom/expatbuilder.py", line 925, in parseString
    return builder.parseString(string)
  File "/usr/lib/python3.8/xml/dom/expatbuilder.py", line 223, in parseString
    parser.Parse(string, True)
TypeError: a bytes-like object is required, not 'NoneType'
```

With this PR
```console
$ rosrun joint_state_publisher_gui  joint_state_publisher_gui
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-sloretz'
Traceback (most recent call last):
  File "/home/sloretz/ws/noetic-misc/devel_isolated/joint_state_publisher_gui/lib/joint_state_publisher_gui/joint_state_publisher_gui", line 15, in <module>
    exec(compile(fh.read(), python_script, 'exec'), context)
  File "/home/sloretz/ws/noetic-misc/src/joint_state_publisher/joint_state_publisher_gui/scripts/joint_state_publisher_gui", line 52, in <module>
    joint_state_publisher.JointStatePublisher(),
  File "<string>", line 145, in __init__
RuntimeError: The robot_description parameter is required and not set.
```