### PR TITLE
[kinetic] Set source_update_cb attr before creating subscribers

### DIFF
--- a/joint_state_publisher/src/joint_state_publisher/__init__.py
+++ b/joint_state_publisher/src/joint_state_publisher/__init__.py
@@ -160,15 +160,15 @@ class JointStatePublisher():
         else:
             self.init_urdf(robot)
 
-        source_list = get_param("source_list", [])
-        self.sources = []
-        for source in source_list:
-            self.sources.append(rospy.Subscriber(source, sensor_msgs.msg.JointState, self.source_cb))
-
         # The source_update_cb will be called at the end of self.source_cb.
         # The main purpose it to allow external observes (such as the
         # joint_state_publisher_gui) to be notified when things are updated.
         self.source_update_cb = None
+
+        source_list = get_param("source_list", [])
+        self.sources = []
+        for source in source_list:
+            self.sources.append(rospy.Subscriber(source, sensor_msgs.msg.JointState, self.source_cb))
 
         self.pub = rospy.Publisher('joint_states', sensor_msgs.msg.JointState, queue_size=5)
 


### PR DESCRIPTION
Fixes #36. It's possible for a subscriber to receive their first message and call the callback prior to `self.source_update_cb` existing. This PR creates the attribute before the subscribers.