### PR TITLE
[Noetic] Use setuptools instead of distutils

### DIFF
--- a/joint_state_publisher/setup.py
+++ b/joint_state_publisher/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/joint_state_publisher_gui/setup.py
+++ b/joint_state_publisher_gui/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Since ros/catkin#1048 catkin prefers to use `setuptools` instead of `distutils`. The `package.xml` doesn't need to include `python3-setuptools` because [catkin exports that dependency](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32) for the convenience of all downstream python packages.