### PR TITLE
Foxy fixes

### DIFF
--- a/joint_state_publisher/pytest.ini
+++ b/joint_state_publisher/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/joint_state_publisher/pytest.ini
+++ b/joint_state_publisher/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+# Avoid warning using pytest >= 5.2 and < 6.0
 junit_family=xunit2

--- a/joint_state_publisher/test/test_64_joint_robot.py
+++ b/joint_state_publisher/test/test_64_joint_robot.py
@@ -30,7 +30,7 @@ def generate_test_description():
     return LaunchDescription([
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
+            executable='joint_state_publisher',
             arguments=[os.path.join(test_urdfs_dir, '64_joint_robot.urdf')]),
         launch_testing.actions.ReadyToTest(),
     ])

--- a/joint_state_publisher/test/test_mimic_chain.py
+++ b/joint_state_publisher/test/test_mimic_chain.py
@@ -30,7 +30,7 @@ def generate_test_description():
     return LaunchDescription([
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
+            executable='joint_state_publisher',
             arguments=[os.path.join(test_urdfs_dir, 'mimic_chain.urdf')]),
         launch_testing.actions.ReadyToTest(),
     ])

--- a/joint_state_publisher/test/test_mimic_cycle.py
+++ b/joint_state_publisher/test/test_mimic_cycle.py
@@ -27,7 +27,7 @@ def generate_test_description():
     test_urdfs_dir = os.path.dirname(__file__)
     joint_state_publisher = Node(
         package='joint_state_publisher',
-        node_executable='joint_state_publisher',
+        executable='joint_state_publisher',
         arguments=[os.path.join(test_urdfs_dir, 'mimic_cycle.urdf')])
     return (
         LaunchDescription([joint_state_publisher, launch_testing.actions.ReadyToTest()]),

--- a/joint_state_publisher/test/test_multi_joints.py
+++ b/joint_state_publisher/test/test_multi_joints.py
@@ -51,30 +51,30 @@ def generate_test_description():
     return LaunchDescription([
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
-            node_name='joint_state_publisher_collada',
+            executable='joint_state_publisher',
+            name='joint_state_publisher_collada',
             arguments=[dae_path],
             remappings=[('joint_states', 'joint_states/collada/from_cli')]),
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
-            node_name='joint_state_publisher_urdf',
+            executable='joint_state_publisher',
+            name='joint_state_publisher_urdf',
             arguments=[urdf_path],
             remappings=[('joint_states', 'joint_states/urdf/from_cli')]),
         ExecuteProcess(cmd=ros2_topic_dae),
         ExecuteProcess(cmd=ros2_topic_urdf),
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
-            node_name='joint_state_publisher_collada_from_topic',
+            executable='joint_state_publisher',
+            name='joint_state_publisher_collada_from_topic',
             remappings=[
                 ('joint_states', 'joint_states/collada/from_topic'),
                 ('robot_description', 'robot_description/dae'),
             ]),
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
-            node_name='joint_state_publisher_urdf_from_topic',
+            executable='joint_state_publisher',
+            name='joint_state_publisher_urdf_from_topic',
             remappings=[
                 ('joint_states', 'joint_states/urdf/from_topic'),
                 ('robot_description', 'robot_description/urdf'),

--- a/joint_state_publisher/test/test_zero_joints.py
+++ b/joint_state_publisher/test/test_zero_joints.py
@@ -30,7 +30,7 @@ def generate_test_description():
     return LaunchDescription([
         Node(
             package='joint_state_publisher',
-            node_executable='joint_state_publisher',
+            executable='joint_state_publisher',
             arguments=[os.path.join(test_urdfs_dir, 'zero_joint_robot.urdf')]),
         launch_testing.actions.ReadyToTest(),
     ])

--- a/joint_state_publisher_gui/pytest.ini
+++ b/joint_state_publisher_gui/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/joint_state_publisher_gui/pytest.ini
+++ b/joint_state_publisher_gui/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+# Avoid warning using pytest >= 5.2 and < 6.0
 junit_family=xunit2


### PR DESCRIPTION
These are a few minor fixes for Foxy so that tests succeed without warnings:

1.  In the test launch files, node_{name,executable} -> {name,executable}
1.  Add a pytest.ini so that tests complete without a junit warning (see the commit message for more details).

Tested to work locally on Foxy.