### PR TITLE
Feature: Custom python functions for dependent joints

### DIFF
--- a/joint_state_publisher/test/nonlinear_dependent_chain.urdf
+++ b/joint_state_publisher/test/nonlinear_dependent_chain.urdf
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<robot name="nonlinear_dependent_chain">
+  <link name="finger1">
+    <visual>
+      <origin xyz="0.0628 -0.0207 0.0" rpy="0 0 -0.2584" />
+      <geometry>
+        <box size="0.149 0.0277 0.07" />
+      </geometry>
+    </visual>
+  </link>
+  <link name="finger2">
+    <visual>
+      <origin xyz="0.0628 0.0207 0.0" rpy="0 0 0.2584" />
+      <geometry>
+        <box size="0.149 0.0277 0.07" />
+      </geometry>
+    </visual>
+  </link>
+  <link name="base">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.001" />
+      </geometry>
+    </visual>
+  </link>
+
+  <link name="piston">
+    <visual>
+      <origin xyz="0 0 -0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.02 0.02 0.2" />
+      </geometry>
+    </visual>
+  </link>
+
+  <joint name="finger1_joint" type="revolute">
+    <origin rpy="0 -1.57 0" xyz="0 -0.033 0" />
+    <parent link="base" />
+    <child link="finger1" />
+    <axis xyz="0 0 -1" />
+    <limit effort="10" velocity="10" lower="-1" upper="1" />
+  </joint>
+  <joint name="finger2_joint" type="revolute">
+    <origin rpy="0 -1.57 0" xyz="0 0.033 0" />
+    <parent link="base" />
+    <child link="finger2" />
+    <axis xyz="0 0 -1" />
+    <limit effort="10" velocity="10" lower="-1" upper="1" />
+  </joint>
+  <joint name="piston_joint" type="prismatic">
+    <parent link="base" />
+    <child link="piston" />
+    <axis xyz="0 0 1"/>
+    <limit effort="10" velocity="10" lower="-0.02" upper="0.04" />
+  </joint>
+</robot>

--- a/joint_state_publisher/test/test_nonlinear_dependent_chain.launch
+++ b/joint_state_publisher/test/test_nonlinear_dependent_chain.launch
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="robot_description" textfile="$(find joint_state_publisher)/test/nonlinear_dependent_chain.urdf"/>
+  
+  <rosparam>
+    dependent_joints:
+      finger1_joint: {
+        parent: piston_joint, 
+        p_off: -0.004,
+        z1: 0.03636756796927724,
+        z2: 0.025,
+        q_off: -0.820403314,
+        fun: "j = parent_position + p_off\nposition = (-2.0 * math.atan2((z1 - math.sqrt(math.pow(z1, 2) + math.pow(z2, 2) - math.pow(j, 2))), (z2 - j))) + q_off"
+      }
+      finger2_joint: {
+        parent: finger1_joint,
+        fun: "position = -1 * parent_position"
+      }
+  </rosparam>
+
+  <node pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" name="dut_joint_state_publisher_gui">
+    <param name="rate" value="10"/>
+  </node>
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
+  <test pkg="rostest" type="hztest" name="hztest" test-name="hztest_mimic_chain">
+    <param name="topic" value="joint_states"/>
+    <param name="hz" value="10"/>
+    <param name="hzerror" value="0.1"/>
+    <param name="test_duration" value="10"/>
+    <param name="wait_time" value="10"/>
+  </test>
+</launch>


### PR DESCRIPTION
Right now, dependent joints can be set using a simple formula: joint = parent_joint * factor + offset

However, in a lot of cases this relationship is not enough, especially for grippers. For example, it is common to deal with different grippers actuated by prismatic pistons.

![gripper_example](https://user-images.githubusercontent.com/14350835/131519620-69f6d2ff-de3a-447b-9a3b-31aab5a809d3.png)

This pull request allows to write custom python functions that are evaluated in runtime. Inside the dependent_joints map, by tag "fun". The parent joint value has the reserved variable name "parent_position". The final value must be stored in the reserved variable "position". Variables are allowed to be set inside the map too.

Example:

dependent_joints:
  finger_1: {parent: piston_joint,
        z1: 0.03636756796927724,
        z2: 0.025,
        q_off: -0.820403314,
        fun: "position = (-2.0 * math.atan2((z1 - math.sqrt(math.pow(z1, 2) + math.pow(z2, 2) - math.pow(parent_position, 2))), (z2 - parent_position))) + q_off"
      }
  finger_2: {parent: finger_1, fun: "position = -1 * parent_position" }

This example is added as a test.

To avoid breaking the current functionality, if no function is provided, it uses the standard joint = parent_joint * factor + offset
