### PR TITLE
Remove deprecated policy warning

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -259,7 +259,7 @@ class JointStatePublisher(rclpy.node.Node):
             self.get_logger().info('Waiting for robot_description to be published on the robot_description topic...')
             self.create_subscription(std_msgs.msg.String, 'robot_description',
                                      lambda msg: self.configure_robot(msg.data),
-                                     rclpy.qos.QoSProfile(depth=1, durability=rclpy.qos.QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL))
+                                     rclpy.qos.QoSProfile(depth=1, durability=rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL))
 
         self.delta = self.get_param('delta')
 


### PR DESCRIPTION
On ROS2 Galactic, Ubuntu 20.04, and Python3.8,

```
$ ros2 run joint_state_publisher joint_state_publisher --ros-args --param zeros.joint_hey:=1.0

[INFO] [1632341480.045667155] [joint_state_publisher]: Waiting for robot_description to be published on the robot_description topic...
/opt/ros/galactic/lib/python3.8/site-packages/rclpy/qos.py:307: UserWarning: DurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL is deprecated. Use DurabilityPolicy.TRANSIENT_LOCAL instead.
  warnings.warn(
```

This PR removes the UserWarning by using `TRANSIENT_LOCAL` instead.