### PR TITLE
Automatically resize window based on number of joints

### DIFF
--- a/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
+++ b/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
@@ -60,6 +60,19 @@ from joint_state_publisher.joint_state_publisher import JointStatePublisher
 from joint_state_publisher_gui.flow_layout import FlowLayout
 
 RANGE = 10000
+LINE_EDIT_WIDTH = 40
+SLIDER_WIDTH = 200
+INIT_NUM_SLIDERS = 7  # Initial number of sliders to show in window
+
+# Defined by style - currently using the default style
+DEFAULT_WINDOW_MARGIN = 11
+DEFAULT_CHILD_MARGIN = 9
+DEFAULT_BTN_HEIGHT = 25
+DEFAULT_SLIDER_HEIGHT = 64  # Is the combination of default heights in Slider
+
+# Calculate default minimums for window sizing
+MIN_WIDTH = SLIDER_WIDTH + DEFAULT_CHILD_MARGIN * 4 + DEFAULT_WINDOW_MARGIN * 2
+MIN_HEIGHT = DEFAULT_BTN_HEIGHT * 2 + DEFAULT_WINDOW_MARGIN * 2 + DEFAULT_CHILD_MARGIN * 2
 
 class Slider(QWidget):
     def __init__(self, name):
@@ -77,7 +90,7 @@ class Slider(QWidget):
         self.display.setAlignment(Qt.AlignRight)
         self.display.setFont(font)
         self.display.setReadOnly(True)
-        self.display.setFixedWidth(40)
+        self.display.setFixedWidth(LINE_EDIT_WIDTH)
         self.row_layout.addWidget(self.display)
 
         self.joint_layout.addLayout(self.row_layout)
@@ -85,8 +98,8 @@ class Slider(QWidget):
         self.slider = QSlider(Qt.Horizontal)
         self.slider.setFont(font)
         self.slider.setRange(0, RANGE)
-        self.slider.setValue(RANGE/2)
-        self.slider.setFixedWidth(200)
+        self.slider.setValue(RANGE / 2)
+        self.slider.setFixedWidth(SLIDER_WIDTH)
 
         self.joint_layout.addWidget(self.slider)
 
@@ -192,6 +205,15 @@ class JointStatePublisherGui(QMainWindow):
 
         # Set zero positions read from parameters
         self.centerEvent(None)
+
+        # Set size of min size of window based on number of sliders.
+        if len(self.sliders) >= INIT_NUM_SLIDERS:  # Limits min size to show INIT_NUM_SLIDERS
+            num_sliders = INIT_NUM_SLIDERS
+        else:
+            num_sliders = len(self.sliders)
+        scroll_layout_height = num_sliders * DEFAULT_SLIDER_HEIGHT
+        scroll_layout_height += (num_sliders - 1) * DEFAULT_CHILD_MARGIN
+        self.setMinimumSize(MIN_WIDTH, scroll_layout_height + MIN_HEIGHT)
 
         self.sliderUpdateTrigger.emit()
 

--- a/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
+++ b/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
@@ -212,7 +212,7 @@ class JointStatePublisherGui(QMainWindow):
         else:
             num_sliders = len(self.sliders)
         scroll_layout_height = num_sliders * DEFAULT_SLIDER_HEIGHT
-        scroll_layout_height += (num_sliders - 1) * DEFAULT_CHILD_MARGIN
+        scroll_layout_height += (num_sliders + 1) * DEFAULT_CHILD_MARGIN
         self.setMinimumSize(MIN_WIDTH, scroll_layout_height + MIN_HEIGHT)
 
         self.sliderUpdateTrigger.emit()


### PR DESCRIPTION
When launching, the gui defaults to a size that always requires the user to resize the window:
![jsp_gui_normal](https://user-images.githubusercontent.com/1350297/134449972-a0dbf77f-fa65-47da-b6bb-a0cd42ae2f14.png)

PR sets the minimum window width based on the original hardcoded width values and default style margins, and sets min height using same approach to initially show 7 sliders at most (scrollbar reappears when more than 7 sliders):
![jsp_gui_pr](https://user-images.githubusercontent.com/1350297/134449969-77ed98ba-a16f-487e-ba41-c02950e9e99a.png)

This leaves it up to the user to resize when the arm has many degrees of freedom, but should automatically scale for the vast majority of robots.