### PR TITLE
Fix the mimic_cycle test to always succeed.

### DIFF
--- a/joint_state_publisher/package.xml
+++ b/joint_state_publisher/package.xml
@@ -23,6 +23,7 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
+  <test_depend>ros2topic</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/joint_state_publisher/test/test_mimic_cycle.py
+++ b/joint_state_publisher/test/test_mimic_cycle.py
@@ -38,7 +38,7 @@ def generate_test_description():
 class TestMimicCycleRobot(unittest.TestCase):
 
     def test_termination(self, proc_info, joint_state_publisher):
-        proc_info.assertWaitForShutdown(process=joint_state_publisher, timeout=(10))
+        proc_info.assertWaitForShutdown(process=joint_state_publisher, timeout=10)
 
 @launch_testing.post_shutdown_test()
 class TestMimicCycleRobotAfterShutdown(unittest.TestCase):

--- a/joint_state_publisher/test/test_mimic_cycle.py
+++ b/joint_state_publisher/test/test_mimic_cycle.py
@@ -19,10 +19,12 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 import launch_testing
 import launch_testing.asserts
+import launch_testing.markers
 import pytest
 
 
 @pytest.mark.rostest
+@launch_testing.markers.keep_alive
 def generate_test_description():
     test_urdfs_dir = os.path.dirname(__file__)
     joint_state_publisher = Node(
@@ -33,12 +35,15 @@ def generate_test_description():
         LaunchDescription([joint_state_publisher, launch_testing.actions.ReadyToTest()]),
         {'joint_state_publisher': joint_state_publisher})
 
+class TestMimicCycleRobot(unittest.TestCase):
+
+    def test_termination(self, proc_info, joint_state_publisher):
+        proc_info.assertWaitForShutdown(process=joint_state_publisher, timeout=(10))
 
 @launch_testing.post_shutdown_test()
-class TestMimicCycleRobot(unittest.TestCase):
+class TestMimicCycleRobotAfterShutdown(unittest.TestCase):
 
     def test_exit(self, proc_info, proc_output):
         jsp = list(proc_info.process_names())[0]
-        # TODO(sloretz) Uncomment when ros2/launch#378 is released
-        # launch_testing.asserts.assertInStderr(jsp, msg='Found an infinite recursive mimic chain')
+        launch_testing.asserts.assertInStderr(proc_output, expected_output='Found an infinite recursive mimic chain', process=jsp)
         launch_testing.asserts.assertExitCodes(proc_info, process=jsp, allowable_exit_codes=[1])


### PR DESCRIPTION
In particular, we weren't keeping the process alive, and we
weren't waiting for the process to finish before checking the
output.  Because of that, the test only worked if the launched
process happened to complete before the checks fired.

Instead, mark things as keep_alive, and make sure to have a
concurrent test that waits for the process to finish before
doing checks.  This makes the test always finish.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is all based on the conversation in https://github.com/ros2/launch/issues/534 .