### PR TITLE
Use underscores in setup.cfg.

### DIFF
--- a/joint_state_publisher/setup.cfg
+++ b/joint_state_publisher/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/joint_state_publisher
+script_dir=$base/lib/joint_state_publisher
 [install]
-install-scripts=$base/lib/joint_state_publisher
+install_scripts=$base/lib/joint_state_publisher

--- a/joint_state_publisher_gui/setup.cfg
+++ b/joint_state_publisher_gui/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/joint_state_publisher_gui
+script_dir=$base/lib/joint_state_publisher_gui
 [install]
-install-scripts=$base/lib/joint_state_publisher_gui
+install_scripts=$base/lib/joint_state_publisher_gui


### PR DESCRIPTION
This is the more standards-oriented way to do things (and
avoids a warning in newer setuptools).

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>