### PR TITLE
[ROS-O Fix] enforce int type for slider values

### DIFF
--- a/joint_state_publisher_gui/src/joint_state_publisher_gui/__init__.py
+++ b/joint_state_publisher_gui/src/joint_state_publisher_gui/__init__.py
@@ -100,7 +100,7 @@ class JointStatePublisherGui(QWidget):
 
             slider.setFont(font)
             slider.setRange(0, RANGE)
-            slider.setValue(RANGE/2)
+            slider.setValue(int(RANGE/2))
 
             joint_layout.addWidget(slider)
 
@@ -222,7 +222,7 @@ class JointStatePublisherGui(QWidget):
         self.update_sliders()
 
     def valueToSlider(self, value, joint):
-        return (value - joint['min']) * float(RANGE) / (joint['max'] - joint['min'])
+        return int((value - joint['min']) * float(RANGE) / (joint['max'] - joint['min']))
 
     def sliderToValue(self, slider, joint):
         pctvalue = slider / float(RANGE)


### PR DESCRIPTION
Fix for Python 3.10 and PyQt 5.15 (possibly earlier versions too).

This patch is required for [the ROS-O initiative](https://github.com/ros-o/). As the patch is fully backward compatible, please merge this into the `noetic-devel` branch and bloom a fixup quick release that includes the patch.

@clalancette 