### PR TITLE
Fix use of joint_state_publisher on Ubuntu Jammy.

### DIFF
--- a/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
+++ b/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
@@ -98,7 +98,7 @@ class Slider(QWidget):
         self.slider = QSlider(Qt.Horizontal)
         self.slider.setFont(font)
         self.slider.setRange(0, RANGE)
-        self.slider.setValue(RANGE / 2)
+        self.slider.setValue(int(RANGE / 2))
         self.slider.setFixedWidth(SLIDER_WIDTH)
 
         self.joint_layout.addWidget(self.slider)
@@ -252,7 +252,7 @@ class JointStatePublisherGui(QMainWindow):
                 self.valueToSlider(random.uniform(joint['min'], joint['max']), joint))
 
     def valueToSlider(self, value, joint):
-        return (value - joint['min']) * float(RANGE) / (joint['max'] - joint['min'])
+        return int((value - joint['min']) * float(RANGE) / (joint['max'] - joint['min']))
 
     def sliderToValue(self, slider, joint):
         pctvalue = slider / float(RANGE)


### PR DESCRIPTION
In particular, the newer version of PyQt is much more
finicky about types, so make sure to pass in ints where
required.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a ROS 2 version of #77 