### PR TITLE
Use rmw_qos_profile_sensor_data for joint_states source subscription

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -39,7 +39,9 @@ import xml.dom.minidom
 
 # ROS 2 imports
 import rclpy
+import rclpy.qos
 import rclpy.node
+from rclpy.qos_overriding_options import QoSOverridingOptions
 from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 import sensor_msgs.msg
 import std_msgs.msg
@@ -266,7 +268,9 @@ class JointStatePublisher(rclpy.node.Node):
         source_list = self.get_param('source_list')
         self.sources = []
         for source in source_list:
-            self.sources.append(self.create_subscription(sensor_msgs.msg.JointState, source, self.source_cb, 10))
+            self.sources.append(self.create_subscription(sensor_msgs.msg.JointState, source, self.source_cb,
+                                                         rclpy.qos.qos_profile_sensor_data,
+                                                         qos_overriding_options=QoSOverridingOptions.with_default_policies()))
 
         # The source_update_cb will be called at the end of self.source_cb.
         # The main purpose is to allow external observers (such as the


### PR DESCRIPTION
I'm using a robot that publishes joint_states with best_effort reliability.  A best_effort subscriber can receive both best effort and reliable topics.  See https://github.com/ros/robot_state_publisher/blob/72e73579d1ffe55e6d92c028d2b6bb311eed8770/src/robot_state_publisher.cpp#L146