### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/joint_state_publisher/package.xml
+++ b/joint_state_publisher/package.xml
@@ -15,6 +15,8 @@
   <url type="bugtracker">https://github.com/ros/joint_state_publisher/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>

--- a/joint_state_publisher/package.xml
+++ b/joint_state_publisher/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>joint_state_publisher</name>
   <version>1.15.1</version>
   <description>

--- a/joint_state_publisher_gui/package.xml
+++ b/joint_state_publisher_gui/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>joint_state_publisher_gui</name>
   <version>1.15.1</version>
   <description>

--- a/joint_state_publisher_gui/package.xml
+++ b/joint_state_publisher_gui/package.xml
@@ -15,6 +15,8 @@
   <url type="bugtracker">https://github.com/ros/joint_state_publisher/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.