### PR TITLE
ros2 sdformat support

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -67,7 +67,7 @@ class JointStatePublisher(rclpy.node.Node):
                 continue
             if child.localName == 'joint':
                 jtype = child.getAttribute('type')
-                if jtype in ('gearbox', 'revolute', 'ball', 'screw', 'universal', 'fixed'):
+                if jtype in ('gearbox', 'revolute2', 'ball', 'screw', 'universal', 'fixed'):
                     continue
                 name = child.getAttribute('name')
                 self.joint_list.append(name)
@@ -81,6 +81,8 @@ class JointStatePublisher(rclpy.node.Node):
                         limit = child.getElementsByTagName('limit')[0]
                         minval = float(limit.getElementsByTagName('lower')[0].firstChild.data)
                         maxval = float(limit.getElementsByTagName('upper')[0].firstChild.data)
+                    except ValueError:
+                        self.get_logger().warn('%s limits are not valid!' % name)
                     except:
                         self.get_logger().warn('%s is not fixed, nor continuous, but limits are not specified!' % name)
                         continue

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -76,6 +76,7 @@ class JointStatePublisher(rclpy.node.Node):
                     maxval = math.pi
                 else:
                     # TODO actual limits
+                    # radians for revolute joints, meters for prismatic joints
                     minval = -math.pi  # xxx
                     maxval = math.pi  # xxx
                     # try:

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -67,25 +67,23 @@ class JointStatePublisher(rclpy.node.Node):
                 continue
             if child.localName == 'joint':
                 jtype = child.getAttribute('type')
-                if jtype in ['gearbox', 'revolute2', 'ball', 'screw', 'universal', 'fixed']:
+                if jtype in ('gearbox', 'revolute2', 'ball', 'screw', 'universal', 'fixed'):
                     continue
                 name = child.getAttribute('name')
                 self.joint_list.append(name)
+
+                # joint limits
                 if jtype == 'continuous':
                     minval = -math.pi
                     maxval = math.pi
                 else:
-                    # TODO actual limits
-                    # radians for revolute joints, meters for prismatic joints
-                    minval = -math.pi  # xxx
-                    maxval = math.pi  # xxx
-                    # try:
-                    #     limit = child.getElementsByTagName('limit')[0]
-                    #     minval = float(limit.getAttribute('lower'))
-                    #     maxval = float(limit.getAttribute('upper'))
-                    # except:
-                    #     self.get_logger().warn('%s is not fixed, nor continuous, but limits are not specified!' % name)
-                    #     continue
+                    try:
+                        limit = child.getElementsByTagName('limit')[0]
+                        minval = float(limit.getElementsByTagName('lower')[0].firstChild.data)
+                        maxval = float(limit.getElementsByTagName('upper')[0].firstChild.data)
+                    except:
+                        self.get_logger().warn('%s is not fixed, nor continuous, but limits are not specified!' % name)
+                        continue
 
                 if self.zeros and name in self.zeros:
                     zeroval = self.zeros[name]
@@ -135,7 +133,7 @@ class JointStatePublisher(rclpy.node.Node):
                 continue
             if child.localName == 'joint':
                 jtype = child.getAttribute('type')
-                if jtype in ['fixed', 'floating', 'planar']:
+                if jtype in ('fixed', 'floating', 'planar'):
                     continue
                 name = child.getAttribute('name')
                 self.joint_list.append(name)
@@ -204,12 +202,16 @@ class JointStatePublisher(rclpy.node.Node):
         self.free_joints = {}
         self.joint_list = [] # for maintaining the original order of the joints
 
-        if robot.getElementsByTagName('sdf'):
+        # Get root tag to parse file format
+        root = robot.documentElement
+        if root.tagName == 'sdf':
             self.init_sdf(robot)
-        elif robot.getElementsByTagName('COLLADA'):
+        elif root.tagName == 'COLLADA':
             self.init_collada(robot)
-        else:
+        elif root.tagName == 'urdf':
             self.init_urdf(robot)
+        else:
+            self.get_logger().error('Cannot parse file of type %s' % root.tagName)
 
         if self.robot_description_update_cb is not None:
             self.robot_description_update_cb()

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -67,7 +67,7 @@ class JointStatePublisher(rclpy.node.Node):
                 continue
             if child.localName == 'joint':
                 jtype = child.getAttribute('type')
-                if jtype in ('gearbox', 'revolute2', 'ball', 'screw', 'universal', 'fixed'):
+                if jtype in ('gearbox', 'revolute', 'ball', 'screw', 'universal', 'fixed'):
                     continue
                 name = child.getAttribute('name')
                 self.joint_list.append(name)

--- a/joint_state_publisher/test/multi_joint_robot.sdf
+++ b/joint_state_publisher/test/multi_joint_robot.sdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name='multi_joint_robot'>
+    <link name="link1"/>
+    <link name="link2"/>
+    <link name="link3"/>
+
+    <joint name='j12' type='revolute'>
+        <parent>link1</parent>
+        <child>link2</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1</lower>
+            <upper>1</upper>
+          </limit>
+        </axis>
+    </joint>
+
+    <joint name='j23' type='revolute'>
+        <parent>link2</parent>
+        <child>link3</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1</lower>
+            <upper>1</upper>
+          </limit>
+        </axis>
+    </joint>
+
+  </model>
+</sdf>

--- a/joint_state_publisher/test/multi_joint_robot.sdf
+++ b/joint_state_publisher/test/multi_joint_robot.sdf
@@ -5,7 +5,7 @@
     <link name="link2"/>
     <link name="link3"/>
 
-    <joint name='j12' type='revolute'>
+    <joint name='j12' type='revolute2'>
         <parent>link1</parent>
         <child>link2</child>
         <axis>
@@ -17,7 +17,7 @@
         </axis>
     </joint>
 
-    <joint name='j23' type='revolute'>
+    <joint name='j23' type='revolute2'>
         <parent>link2</parent>
         <child>link3</child>
         <axis>

--- a/joint_state_publisher/test/multi_joint_robot.sdf
+++ b/joint_state_publisher/test/multi_joint_robot.sdf
@@ -5,7 +5,7 @@
     <link name="link2"/>
     <link name="link3"/>
 
-    <joint name='j12' type='revolute2'>
+    <joint name='j12' type='revolute'>
         <parent>link1</parent>
         <child>link2</child>
         <axis>
@@ -17,7 +17,7 @@
         </axis>
     </joint>
 
-    <joint name='j23' type='revolute2'>
+    <joint name='j23' type='revolute'>
         <parent>link2</parent>
         <child>link3</child>
         <axis>

--- a/joint_state_publisher/test/test_multi_joints.py
+++ b/joint_state_publisher/test/test_multi_joints.py
@@ -60,19 +60,22 @@ def generate_test_description():
             executable='joint_state_publisher',
             name='joint_state_publisher_collada',
             arguments=[dae_path],
-            remappings=[('joint_states', 'joint_states/collada/from_cli')]),
+            remappings=[('joint_states', 'joint_states/collada/from_cli')],
+            output=['screen']),
         Node(
             package='joint_state_publisher',
             executable='joint_state_publisher',
             name='joint_state_publisher_sdf',
             arguments=[sdf_path],
-            remappings=[('joint_states', 'joint_states/sdf/from_cli')]),
+            remappings=[('joint_states', 'joint_states/sdf/from_cli')],
+            output=['screen']),
         Node(
             package='joint_state_publisher',
             executable='joint_state_publisher',
             name='joint_state_publisher_urdf',
             arguments=[urdf_path],
-            remappings=[('joint_states', 'joint_states/urdf/from_cli')]),
+            remappings=[('joint_states', 'joint_states/urdf/from_cli')],
+            output=['screen']),
         ExecuteProcess(cmd=ros2_topic_dae),
         ExecuteProcess(cmd=ros2_topic_sdf),
         ExecuteProcess(cmd=ros2_topic_urdf),
@@ -83,7 +86,8 @@ def generate_test_description():
             remappings=[
                 ('joint_states', 'joint_states/collada/from_topic'),
                 ('robot_description', 'robot_description/dae'),
-            ]),
+            ],
+            output=['screen']),
         Node(
             package='joint_state_publisher',
             executable='joint_state_publisher',
@@ -91,7 +95,8 @@ def generate_test_description():
             remappings=[
                 ('joint_states', 'joint_states/sdf/from_topic'),
                 ('robot_description', 'robot_description/sdf'),
-            ]),
+            ],
+            output=['screen']),
         Node(
             package='joint_state_publisher',
             executable='joint_state_publisher',
@@ -99,7 +104,8 @@ def generate_test_description():
             remappings=[
                 ('joint_states', 'joint_states/urdf/from_topic'),
                 ('robot_description', 'robot_description/urdf'),
-            ]),
+            ],
+            output=['screen']),
         launch_testing.actions.ReadyToTest(),
     ])
 

--- a/joint_state_publisher/test/test_multi_joints.py
+++ b/joint_state_publisher/test/test_multi_joints.py
@@ -29,23 +29,29 @@ import yaml
 
 @pytest.mark.rostest
 def generate_test_description():
-    test_urdfs_dir = os.path.dirname(__file__)
+    test_dir = os.path.dirname(__file__)
 
-    dae_path = os.path.join(test_urdfs_dir, 'multi_joint_robot.dae')
-    urdf_path = os.path.join(test_urdfs_dir, 'multi_joint_robot.urdf')
+    dae_path = os.path.join(test_dir, 'multi_joint_robot.dae')
+    sdf_path = os.path.join(test_dir, 'multi_joint_robot.sdf')
+    urdf_path = os.path.join(test_dir, 'multi_joint_robot.urdf')
 
     with open(dae_path, 'r') as dae_file:
         dae_text = dae_file.read()
+
+    with open(sdf_path, 'r') as sdf_file:
+        sdf_text = sdf_file.read()
 
     with open(urdf_path, 'r') as urdf_file:
         urdf_text = urdf_file.read()
 
     dae_yaml = yaml.dump({'data': dae_text})
+    sdf_yaml =  yaml.dump({'data': sdf_text})
     urdf_yaml = yaml.dump({'data': urdf_text})
 
     ros2_topic_cmd = ['ros2', 'topic', 'pub', '--qos-durability', 'transient_local']
 
     ros2_topic_dae = ros2_topic_cmd + ['robot_description/dae', 'std_msgs/msg/String', dae_yaml]
+    ros2_topic_sdf = ros2_topic_cmd + ['robot_description/sdf', 'std_msgs/msg/String', sdf_yaml]
     ros2_topic_urdf = ros2_topic_cmd + ['robot_description/urdf', 'std_msgs/msg/String', urdf_yaml]
 
     return LaunchDescription([
@@ -58,10 +64,17 @@ def generate_test_description():
         Node(
             package='joint_state_publisher',
             executable='joint_state_publisher',
+            name='joint_state_publisher_sdf',
+            arguments=[sdf_path],
+            remappings=[('joint_states', 'joint_states/sdf/from_cli')]),
+        Node(
+            package='joint_state_publisher',
+            executable='joint_state_publisher',
             name='joint_state_publisher_urdf',
             arguments=[urdf_path],
             remappings=[('joint_states', 'joint_states/urdf/from_cli')]),
         ExecuteProcess(cmd=ros2_topic_dae),
+        ExecuteProcess(cmd=ros2_topic_sdf),
         ExecuteProcess(cmd=ros2_topic_urdf),
         Node(
             package='joint_state_publisher',
@@ -70,6 +83,14 @@ def generate_test_description():
             remappings=[
                 ('joint_states', 'joint_states/collada/from_topic'),
                 ('robot_description', 'robot_description/dae'),
+            ]),
+        Node(
+            package='joint_state_publisher',
+            executable='joint_state_publisher',
+            name='joint_state_publisher_sdf_from_topic',
+            remappings=[
+                ('joint_states', 'joint_states/sdf/from_topic'),
+                ('robot_description', 'robot_description/sdf'),
             ]),
         Node(
             package='joint_state_publisher',
@@ -106,6 +127,10 @@ class TestMultiJoint(unittest.TestCase):
         sub_collada = self.node.create_subscription(
             sensor_msgs.msg.JointState, 'joint_states/collada/from_cli',
             lambda msg: msgs_rx_collada_from_cli.append(msg), 1)
+        msgs_rx_sdf_from_cli = []
+        sub_sdf = self.node.create_subscription(
+            sensor_msgs.msg.JointState, 'joint_states/sdf/from_cli',
+            lambda msg: msgs_rx_sdf_from_cli.append(msg), 1)
         msgs_rx_urdf_from_cli = []
         sub_urdf = self.node.create_subscription(
             sensor_msgs.msg.JointState, 'joint_states/urdf/from_cli',
@@ -114,6 +139,10 @@ class TestMultiJoint(unittest.TestCase):
         sub_collada = self.node.create_subscription(
             sensor_msgs.msg.JointState, 'joint_states/collada/from_topic',
             lambda msg: msgs_rx_collada_from_topic.append(msg), 1)
+        msgs_rx_sdf_from_topic = []
+        sub_sdf = self.node.create_subscription(
+            sensor_msgs.msg.JointState, 'joint_states/sdf/from_topic',
+            lambda msg: msgs_rx_sdf_from_topic.append(msg), 1)
         msgs_rx_urdf_from_topic = []
         sub_urdf = self.node.create_subscription(
             sensor_msgs.msg.JointState, 'joint_states/urdf/from_topic',
@@ -121,14 +150,16 @@ class TestMultiJoint(unittest.TestCase):
         try:
             end_time = time.monotonic() + self.TIMEOUT
             msg_lists = (
-                msgs_rx_collada_from_cli, msgs_rx_urdf_from_cli,
-                msgs_rx_collada_from_topic, msgs_rx_urdf_from_topic)
+                msgs_rx_collada_from_cli, msgs_rx_sdf_from_cli, msgs_rx_urdf_from_cli,
+                msgs_rx_collada_from_topic, msgs_rx_sdf_from_topic, msgs_rx_urdf_from_topic)
             while time.monotonic() < end_time and not all(msg_lists):
                 rclpy.spin_once(self.node, timeout_sec=0.1)
 
             assert msgs_rx_collada_from_cli
+            assert msgs_rx_sdf_from_cli
             assert msgs_rx_urdf_from_cli
             assert msgs_rx_collada_from_topic
+            assert msgs_rx_sdf_from_topic
             assert msgs_rx_urdf_from_topic
             for msg in itertools.chain.from_iterable(msg_lists):
                 assert 2 == len(msg.name)
@@ -138,4 +169,5 @@ class TestMultiJoint(unittest.TestCase):
                 assert {'j12': 0.0, 'j23': 0.0} == dict(zip(msg.name, msg.position))
         finally:
             self.node.destroy_subscription(sub_collada)
+            self.node.destroy_subscription(sub_sdf)
             self.node.destroy_subscription(sub_urdf)


### PR DESCRIPTION
Builds upon https://github.com/ros/joint_state_publisher/pull/55.

Addressed review comments here and extended to:
- Add a root tag check for the format
- Using tuple instead of lists
- Test sdf parsing in test_multi_joints.py
- parsing joint limits for sdf
- simple two joint model sdf file