### PR TITLE
add 'relay_sources' option

### DIFF
--- a/joint_state_publisher/README.md
+++ b/joint_state_publisher/README.md
@@ -24,6 +24,7 @@ Parameters
 * `use_mimic_tags` (bool) - Whether to honor `<mimic>` tags in the URDF.  Defaults to True.
 * `use_smallest_joint_limits` (bool) - Whether to honor `<safety_controller>` tags in the URDF.  Defaults to True.
 * `source_list` (array of strings) - Each string in this array represents a topic name.  For each string, create a subscription to the named topic of type `sensor_msgs/msg/JointStates`.  Publication to that topic will update the joints named in the message.  Defaults to an empty array.
+* `relay_sources` (bool) - Whether to immediately republish messages coming in on topics from `source_list`. Makes for smoother joints sometimes. Defaults to False.
 * `delta` (double) - How much to automatically move joints during each iteration.  Defaults to 0.0.
 
 #### Mapped Parameters

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -460,7 +460,7 @@ class JointStatePublisher(rclpy.node.Node):
 
         if self.source_update_cb is not None:
             self.source_update_cb()
-        
+
         if self.get_param('relay_sources'):
             self.pub.publish(msg)
 

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -364,7 +364,7 @@ class JointStatePublisher(rclpy.node.Node):
                                    ParameterDescriptor(type=ParameterType.PARAMETER_INTEGER))
         self.declare_ros_parameter('source_list', [],
                                    ParameterDescriptor(type=ParameterType.PARAMETER_STRING_ARRAY))
-        self.declare_ros_parameter('relay_sources', True,
+        self.declare_ros_parameter('relay_sources', False,
                                    ParameterDescriptor(type=ParameterType.PARAMETER_BOOL))
         self.declare_ros_parameter('use_mimic_tags', True,
                                    ParameterDescriptor(type=ParameterType.PARAMETER_BOOL))

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -364,6 +364,8 @@ class JointStatePublisher(rclpy.node.Node):
                                    ParameterDescriptor(type=ParameterType.PARAMETER_INTEGER))
         self.declare_ros_parameter('source_list', [],
                                    ParameterDescriptor(type=ParameterType.PARAMETER_STRING_ARRAY))
+        self.declare_ros_parameter('relay_sources', True,
+                                   ParameterDescriptor(type=ParameterType.PARAMETER_BOOL))
         self.declare_ros_parameter('use_mimic_tags', True,
                                    ParameterDescriptor(type=ParameterType.PARAMETER_BOOL))
         self.declare_ros_parameter('use_smallest_joint_limits', True,
@@ -458,6 +460,9 @@ class JointStatePublisher(rclpy.node.Node):
 
         if self.source_update_cb is not None:
             self.source_update_cb()
+        
+        if self.get_param('relay_sources'):
+            self.pub.publish(msg)
 
     def set_source_update_cb(self, user_cb):
         self.source_update_cb = user_cb


### PR DESCRIPTION
immediately relaying the incoming messages is useful when the joints must update in sync with other things happening.

One example where not having this option breaks things is [fssim](https://github.com/AMZ-Racing/fssim?tab=readme-ov-file#known-problems) where for the visualization in rviz the fixed frame is the `map` and the camera moves together with `base_footprint`, it often fails to find transforms in the same timeframe.