### PR TITLE
Add `offset-timestamp` param

### DIFF
--- a/joint_state_publisher/README.md
+++ b/joint_state_publisher/README.md
@@ -18,6 +18,7 @@ Subscribed Topics
 Parameters
 ----------
 * `rate` (int) - The rate at which to publish updates to the `/joint_states` topic.  Defaults to 10.
+* `offset_timestamp`(double) - The offset to add to the timestamp of the published message, in seconds. Defaults to 0.0.
 * `publish_default_positions` (bool) - Whether to publish a default position for each movable joint to the `/joint_states` topic.  Defaults to True.
 * `publish_default_velocities` (bool) - Whether to publish a default velocity for each movable joint to the `/joint_states` topic.  Defaults to False.
 * `publish_default_efforts` (bool) - Whether to publish a default effort for each movable joint to the `/joint_states` topic.  Defaults to False.

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -370,6 +370,8 @@ class JointStatePublisher(rclpy.node.Node):
                                    ParameterDescriptor(type=ParameterType.PARAMETER_BOOL))
         self.declare_ros_parameter('delta', 0.0,
                                    ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
+        self.declare_ros_parameter('offset_timestamp', 0.0,
+                                   ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE))
         # In theory we would also declare 'dependent_joints' and 'zeros' here.
         # Since rclpy doesn't support maps natively, though, we just end up
         # letting 'automatically_declare_parameters_from_overrides' declare
@@ -390,6 +392,7 @@ class JointStatePublisher(rclpy.node.Node):
         self.pub_def_positions = self.get_param('publish_default_positions')
         self.pub_def_vels = self.get_param('publish_default_velocities')
         self.pub_def_efforts = self.get_param('publish_default_efforts')
+        self.offset_timestamp = self.get_param('offset_timestamp')
 
         self.robot_description_update_cb = None
 
@@ -468,8 +471,7 @@ class JointStatePublisher(rclpy.node.Node):
     def timer_callback(self):
         # Publish Joint States
         msg = sensor_msgs.msg.JointState()
-        msg.header.stamp = self.get_clock().now().to_msg()
-
+        msg.header.stamp = (self.get_clock().now() + rclpy.duration.Duration(seconds=self.offset_timestamp)).to_msg()
         if self.delta > 0:
             self.update(self.delta)
 


### PR DESCRIPTION
I have added a new parameter `offset_timestamp` to the `joint_state_publisher`.

Here’s an explanation of why I needed this parameter, and I believe other developers might also find it useful.

My robot setup is as follows: the `gimbal_yaw` and `gimbal_pitch` are actuable, and their attitude is obtained via the IMU sensor on the embedded development board. The data is then transmitted to the NUC via UART as a `JointState` type. I use the `joint_state_publisher` and `robot_state_publisher` to publish the full vehicle’s TF data.

![robot_model](https://raw.githubusercontent.com/LihanChen2004/picx-images-hosting/master/sentry_description.1sf3yc69kr.webp)

![frames](https://raw.githubusercontent.com/LihanChen2004/picx-images-hosting/master/frames.5xaq4wriyy.webp)

One subtle issue is that there is a delay in the data transfer from the embedded development board to the NUC (approximately 0.008 seconds in our system based on testing). Although this delay is small, the real-time nature of our development work makes it impactful. It causes an apparent lag in the transformation of the `gimbal_pitch` sensor into `chassis` (or other fixed world coordinate frame). After adding the `offset_timestamp`, the issue was significantly mitigated.
