### PR TITLE
Promote “Got description, configuring robot” log to INFO in joint_state_publisher

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -279,7 +279,7 @@ class JointStatePublisher(rclpy.node.Node):
         return (free_joints, joint_list, dependent_joints)
 
     def configure_robot(self, description):
-        self.get_logger().debug('Got description, configuring robot')
+        self.get_logger().info('Got description, configuring robot')
         xmldom = xml.dom.minidom.parseString(description)
 
         root = xmldom.documentElement


### PR DESCRIPTION
## Promote robot_description success log to INFO

### Summary
This merge request changes the log level of the message:
`Got description, configuring robot`  
in `joint_state_publisher` from `DEBUG` to `INFO`.

### Motivation
Currently, the node logs:
```text
[INFO] Waiting for robot_description to be published on the robot_description topic...
```
but only logs that it received and processed the description at `DEBUG` level:
```text
[DEBUG] Got description, configuring robot
```
This leads to confusion during development and debugging, because it appears the robot description was never received, even when everything is working correctly.


### Impact
- Improves developer UX by making successful reception of the robot description visible at default logging levels.
- No runtime or behavioral changes.

### Related Discussions
- Internal debugging of a launch issue showed this log level mismatch was misleading
- Consistency with the `Waiting for robot_description` message which is already `INFO`
- Fixes [#113](https://github.com/ros/joint_state_publisher/issues/113)

### Notes
Let me know if there’s a reason it was originally left at DEBUG—happy to adjust if needed.
