### PR TITLE
Editable joint position text boxes

### DIFF
--- a/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
+++ b/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
@@ -237,17 +237,23 @@ class JointStatePublisherGui(QMainWindow):
     def onDisplayValueChangedOne(self, name):
         joint_info = self.joint_map[name]
         display = joint_info['display']
+        joint = joint_info['joint']
         try:
             value = float(display.text())
         except ValueError:
-            display.setText(f"{joint_info['joint']['position']:.3f}")
+            value = None
+        # NaN would bypass the clamp below and end up published on /joint_states
+        if value is None or not math.isfinite(value):
+            display.setText(f"{joint['position']:.3f}")
             return
-        clamped_value = max(min(value, joint_info['joint']['max']), joint_info['joint']['min'])
-        joint_info['joint']['position'] = clamped_value
-        joint_info['display'].setText(f"{clamped_value:.3f}")
+        clamped_value = max(min(value, joint['max']), joint['min'])
+        joint['position'] = clamped_value
+        display.setText(f'{clamped_value:.3f}')
         joint_info['slider'].blockSignals(True)
-        joint_info['slider'].setValue(self.valueToSlider(clamped_value, joint_info['joint']))
-        joint_info['slider'].blockSignals(False)
+        try:
+            joint_info['slider'].setValue(self.valueToSlider(clamped_value, joint))
+        finally:
+            joint_info['slider'].blockSignals(False)
 
     @Slot()
     def updateSliders(self):

--- a/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
+++ b/joint_state_publisher_gui/joint_state_publisher_gui/joint_state_publisher_gui.py
@@ -88,7 +88,7 @@ class Slider(QWidget):
         self.display = QLineEdit('0.00')
         self.display.setAlignment(Qt.AlignmentFlag.AlignRight)
         self.display.setFont(font)
-        self.display.setReadOnly(True)
+        self.display.setReadOnly(False)
         self.display.setFixedWidth(LINE_EDIT_WIDTH)
         self.row_layout.addWidget(self.display)
 
@@ -201,6 +201,8 @@ class JointStatePublisherGui(QMainWindow):
             # Connect to the signal provided by QSignal
             slider.slider.valueChanged.connect(
                 lambda event, name=name: self.onSliderValueChangedOne(name))
+            slider.display.editingFinished.connect(
+                lambda name=name: self.onDisplayValueChangedOne(name))
 
             self.sliders[slider] = slider
 
@@ -231,6 +233,21 @@ class JointStatePublisherGui(QMainWindow):
         joint = joint_info['joint']
         joint['position'] = self.sliderToValue(slidervalue, joint)
         joint_info['display'].setText(f"{joint['position']:.3f}")
+
+    def onDisplayValueChangedOne(self, name):
+        joint_info = self.joint_map[name]
+        display = joint_info['display']
+        try:
+            value = float(display.text())
+        except ValueError:
+            display.setText(f"{joint_info['joint']['position']:.3f}")
+            return
+        clamped_value = max(min(value, joint_info['joint']['max']), joint_info['joint']['min'])
+        joint_info['joint']['position'] = clamped_value
+        joint_info['display'].setText(f"{clamped_value:.3f}")
+        joint_info['slider'].blockSignals(True)
+        joint_info['slider'].setValue(self.valueToSlider(clamped_value, joint_info['joint']))
+        joint_info['slider'].blockSignals(False)
 
     @Slot()
     def updateSliders(self):


### PR DESCRIPTION
Updates the display text boxes to be editable, making debugging easier by allowing the desired joint position to be typed in rather than trying to move the slider to a value that is close to the desired position.

- Checks that the typed value is within the joint limits and is a valid number. Invalid inputs will revert back to the previous value
- Updates sliders and joint values when the text box is edited